### PR TITLE
Fix double sign in method UI when using email

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,9 @@ new Vue({
       if(user) {
         this.$router.push('/success')
       } else {
-        this.$router.push('/auth')
+        if (this.$route.path !== '/auth') {
+          this.$router.push('/auth')
+        }
       }
      });
     },


### PR DESCRIPTION
Pushing /auth again after the Account Chooser redirect caused
?mode=select to be stripped off the URL, resulting in the sign in method
UI/dialog to be presented again instead of the password UI/dialog.

Sign-in would still work if 'Sign in with email' was clicked again, but
this PR corrects the behaviour.